### PR TITLE
Responsive map dimensions and color scale

### DIFF
--- a/map.py
+++ b/map.py
@@ -83,7 +83,8 @@ def iframe():
         )
         
     choropleth.add_to(m)
-    choropleth.color_scale.width = 1000
+    choropleth.color_scale.caption = "Incident Count"
+    legend_html = choropleth.color_scale._repr_html_()
 
     folium.GeoJson(
         geojson_data,
@@ -97,9 +98,9 @@ def iframe():
 
     folium.LayerControl().add_to(m)
 
-    # set the iframe width and height
-    m.get_root().width = "1100px"
-    m.get_root().height = "1000px"
+    # set the iframe width and height to fill its container
+    m.get_root().width = "100%"
+    m.get_root().height = "100%"
     iframe = m.get_root()._repr_html_()
 
     return render_template('index.html', 
@@ -109,7 +110,8 @@ def iframe():
                            selected_categories=selected_categories,
                            selected_groups=selected_groups,
                            selected_type_groups=selected_type_groups,
-                           iframe=iframe)
+                           iframe=iframe,
+                           legend=legend_html)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,11 +10,21 @@
     option {
       color: black;
     }
+    #map-container {
+      height: 70vh;
+    }
+    #map-container > * {
+      height: 100% !important;
+      width: 100% !important;
+    }
+    #legend-container {
+      margin-top: 1rem;
+    }
   </style>
 </head>
 <body>
 
-<div class="container ml-1">
+<div class="container-fluid ml-1">
   <div class="row">
     <div class="col-md-5">
       <h1>Edmonton Safety Map</h1>
@@ -44,10 +54,27 @@
       </form>
     </div>
     <div class="col-md-7">
-      {{ iframe|safe }}
+      <div id="map-container">
+        {{ iframe|safe }}
+      </div>
+      <div id="legend-container">
+        {{ legend|safe }}
+      </div>
     </div>
   </div>
 </div>
+
+<script>
+  function sizeLegend() {
+    const map = document.querySelector('#map-container').firstElementChild;
+    const legendSvg = document.querySelector('#legend-container svg');
+    if (map && legendSvg) {
+      legendSvg.style.width = map.clientWidth + 'px';
+    }
+  }
+  window.addEventListener('load', sizeLegend);
+  window.addEventListener('resize', sizeLegend);
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- tweak `map.py` to provide legend HTML and use 100% map width/height
- embed map and legend into containers that adapt to viewport
- dynamically resize color scale to match map width

## Testing
- `python -m py_compile map.py`