### PR TITLE
Add map note on approximate locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Edmonton Safety Map
+
+This project shows Edmonton Police Service incident data on an interactive map. Use it to explore which communities experience more crime and filter by different categories or types.
+
+Data is available from 2022 through 2025. The 2025 data only goes up to **May 28**.
+
+### How the map is prepared
+
+> According to EPS, "To anonymize the location of the incident the point on the map is relocated to the closest intersection to where they occurred and should be considered approximate." This means each row in the EPS dataset marks only an approximate spot.
+>
+> For each data point, the related community is determined using the city's [neighbourhood boundaries](https://data.edmonton.ca/dataset/Neighbourhood-Boundaries-2019/xu6q-xcmj/about_data).

--- a/templates/index.html
+++ b/templates/index.html
@@ -65,11 +65,16 @@
             </a>
             for detailed descriptions of the incident categories and types. If no category or type is selected, all incidents are shown.
           </p>
+          <div class="alert alert-info" role="alert">
+            <strong>Heads up:</strong> EPS says each incident is moved to the nearest intersection,
+            so the points are only approximate. We match every record to a community
+            using the city's <a href="https://data.edmonton.ca/dataset/Neighbourhood-Boundaries-2019/xu6q-xcmj/about_data" target="_blank">neighbourhood boundaries</a>.
+          </div>
           <form action="/" method="post">
         <div class="mb-3">
           <label for="year"><strong>Data Year</strong>
             <i class="fas fa-info-circle" data-toggle="tooltip"
-               title="Data for 2022–2024 represent complete years, while 2025 contains incidents up to May 17 only."></i>
+               title="Data for 2022–2024 represent complete years, while 2025 contains incidents up to May 28 only."></i>
           </label>
           <select id="year" class="custom-select" name="year" onchange="this.form.submit()">
             {% for y in years %}


### PR DESCRIPTION
## Summary
- display additional note on the webpage that incident points are approximate and matched to communities using neighbourhood boundaries

## Testing
- `python -m py_compile map.py`


------
https://chatgpt.com/codex/tasks/task_e_683a0ef425708321919d679ad941df81