### PR TITLE
Move EPS disclaimer to Heads Up section

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -55,8 +55,7 @@
           <h1 class="h3 mb-3">Edmonton Safety Map</h1>
           <p class="text-muted">
             Use the filters below to explore where incidents were reported across Edmonton.
-            The numbers show recorded occurrences only and should not be read as direct
-            crime rates. EPS explains, "Occurrences in your neighbourhood can be both criminal and non-criminal. Not all police activity is in response to crime. Regardless of where you live, the potential for police activity exists." Select a data year and optionally filter by <strong>category</strong>
+            Select a data year and optionally filter by <strong>category</strong>
             or <strong>type</strong>. Hold <kbd>Ctrl</kbd> (PC) or <kbd>Command</kbd> (Mac)
             while clicking to choose more than one option.
           </p>
@@ -68,9 +67,16 @@
             for detailed descriptions of the incident categories and types. If no category or type is selected, all incidents are shown.
           </p>
           <div class="alert alert-info" role="alert">
-            <strong>Heads up:</strong> EPS says each incident is moved to the nearest intersection,
-            so the points are only approximate. We match every record to a community
-            using the city's <a href="https://data.edmonton.ca/dataset/Neighbourhood-Boundaries-2019/xu6q-xcmj/about_data" target="_blank">neighbourhood boundaries</a>.
+            <strong>Heads up:</strong>
+            <p class="mb-2">
+              The numbers show recorded occurrences only and should not be read as direct crime rates.
+              EPS explains, "Occurrences in your neighbourhood can be both criminal and non-criminal. Not all police activity is in response to crime. Regardless of where you live, the potential for police activity exists."
+            </p>
+            <p class="mb-0">
+              EPS says each incident is moved to the nearest intersection,
+              so the points are only approximate. We match every record to a community
+              using the city's <a href="https://data.edmonton.ca/dataset/Neighbourhood-Boundaries-2019/xu6q-xcmj/about_data" target="_blank">neighbourhood boundaries</a>.
+            </p>
           </div>
           <p class="text-muted small">
             Data comes from open EPS incident reports and City of Edmonton boundaries.


### PR DESCRIPTION
## Summary
- clarify README intro
- separate Heads up disclaimer into two paragraphs
- remove disclaimer from the intro section
- restore README intro text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a2ada0388832187dcc6c339ef96a2